### PR TITLE
fixed error when add secondary_endpoint

### DIFF
--- a/app/models/graphiti/open_api/endpoint.rb
+++ b/app/models/graphiti/open_api/endpoint.rb
@@ -25,7 +25,7 @@ module Graphiti::OpenAPI
       {
         path => {
           parameters: parameters,
-        }.merge(collection_actions.map(&:operation).inject(&:merge)),
+        }.merge(collection_actions.map(&:operation).inject(&:merge) || {}),
         resource_path => {
           parameters: [{'$ref': "#/components/parameters/#{resource.type}_id"}] + parameters,
         }.merge(resource_actions.map(&:operation).inject(&:merge)),


### PR DESCRIPTION
Just fixed the error.

`TypeError: no implicit conversion of nil into Hash`

```
class LockResource < ApplicationResource 
  secondary_endpoint '/locks/unlock', [:unlock]
end
```